### PR TITLE
Fix lint errors in Blog and Navigation

### DIFF
--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -417,12 +417,12 @@ Let's build technology that not only solves problems but does so responsibly.
                 <ReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   components={{
-                    code({ className, children, ...props }: any) {
+                    code({ className, children, ...props }: { className?: string; children?: React.ReactNode } & React.HTMLAttributes<HTMLElement>) {
                       const match = /language-(\w+)/.exec(className || '');
                       const isInline = !match;
                       return !isInline ? (
                         <SyntaxHighlighter
-                          style={tomorrow as any}
+                          style={tomorrow}
                           language={match![1]}
                           PreTag="div"
                         >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -80,7 +80,7 @@ const Navigation: React.FC<NavigationProps> = () => {
           
           try {
             element.focus();
-          } catch (e) {
+          } catch {
             // Focus failed silently
           }
           setIsLoading(false);
@@ -125,7 +125,7 @@ const Navigation: React.FC<NavigationProps> = () => {
             
             try {
               element.focus();
-            } catch (e) {
+            } catch {
               // Focus failed silently
             }
             setIsLoading(false);


### PR DESCRIPTION
## Summary
- eliminate `any` usage in Blog Markdown renderer
- remove unused catch parameters in Navigation component
- ensure lint succeeds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b2141a1748332b0fa0c3158f40ba7